### PR TITLE
Proxy support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
+// initialize proxy support
+require('global-agent').bootstrap();
+global.GLOBAL_AGENT.HTTP_PROXY = process.env.HTTP_PROXY
+
 module.exports = MiddlewareBase => class Rewrite extends MiddlewareBase {
   description () {
     return 'URL Rewriting. Use to re-route requests to local or remote destinations.'

--- a/index.js
+++ b/index.js
@@ -19,12 +19,6 @@ module.exports = MiddlewareBase => class Rewrite extends MiddlewareBase {
     const arrayify = require('array-back')
     const routes = parseRewriteRules(arrayify(options.rewrite))
 
-    /* re-use proxy sockets using keep-alive  */
-    const http = require('http')
-    http.globalAgent = new http.Agent({ keepAlive: true })
-    const https = require('https')
-    https.globalAgent = new https.Agent({ keepAlive: true })
-
     if (routes.length) {
       this.emit('verbose', 'middleware.rewrite.config', { rewrite: routes })
       return routes.map(route => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "boolean": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-0.2.0.tgz",
+      "integrity": "sha512-mDcM3ChboDuhv4glLXEH1us7jMiWXRSs3R13Okoo+kkFOlLIjvF1y88507wTfDf9zsuv0YffSDFUwX95VAT/mg=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -188,6 +193,11 @@
         "keygrip": "~1.0.2"
       }
     },
+    "core-js": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.1.tgz",
+      "integrity": "sha512-OddJJmAMN6czmPEtp1ScHFWq4RXzH1iWJFGL8CZ6UcopeBzCMjo4Slv0UoLW2hhny1/wsDowm6xCmBCWQ1azkA=="
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -242,6 +252,11 @@
       "resolved": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz",
       "integrity": "sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc=",
       "dev": true
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -312,6 +327,26 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "global-agent": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-1.7.1.tgz",
+      "integrity": "sha512-ceppEkOpS6lPjvRw7DDkwXWkMpw37rDv2gChQ9wWWfOvj1QZnyuXbGBBGyig6i6Hs3l+B3QrhxiQcsxiwWFoAw==",
+      "requires": {
+        "core-js": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^2.0.0",
+        "roarr": "^2.13.0",
+        "semver": "^6.0.0",
+        "serialize-error": "^4.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+          "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
+        }
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -372,6 +407,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "keygrip": {
       "version": "1.0.2",
@@ -570,6 +610,21 @@
         "koa-static": "^4.0.2"
       }
     },
+    "matcher": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-2.0.0.tgz",
+      "integrity": "sha512-nlmfSlgHBFx36j/Pl/KQPbIaqE8Zf0TqmSMjsuddHDg6PMSVgmyW9HpkLs0o0M1n2GIZ/S2BZBLIww/xjhiGng==",
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+        }
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -711,17 +766,46 @@
         "path-is-absolute": "1.0.1"
       }
     },
+    "roarr": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.13.2.tgz",
+      "integrity": "sha512-HQUuk0VVFmzSrAMFOimSXRBZ8KJu8qH8LOm4ltnJCsQTZr8QQbneI9pzfW3m37Jiq+6oR9c0Xc+W4xnbi7QLKw==",
+      "requires": {
+        "boolean": "^0.2.0",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      }
+    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+    },
+    "serialize-error": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-4.1.0.tgz",
+      "integrity": "sha512-5j9GgyGsP9vV9Uj1S0lDCvlsd+gc2LEPVK7HHHte7IyPwOD4lVQFeaX143gx3U5AnoCi+wbcb3mvaxVysjpxEw==",
+      "requires": {
+        "type-fest": "^0.3.0"
+      }
+    },
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "statuses": {
       "version": "1.5.0",
@@ -811,6 +895,11 @@
       "requires": {
         "thenify": ">= 3.1.0 < 4"
       }
+    },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
     },
     "type-is": {
       "version": "1.6.16",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "array-back": "^2.0.0",
+    "global-agent": "^1.7.1",
     "koa-rewrite-75lb": "^2.1.1",
     "koa-route": "^3.2.0",
     "path-to-regexp": "^1.7.0",


### PR DESCRIPTION
This commit removes the global httpAgent overwrite on the rewrite module, so the one from an eventual exteral overwrite can be used.
This is required for `global-tunnel-ng` proxy support.