### PR TITLE
add rewrite.dropsecurecookieflag option

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,11 @@ class Rewrite extends EventEmitter {
         multiple: true,
         typeLabel: '{underline expression} ...',
         description: "A list of URL rewrite rules. For each rule, separate the 'from' and 'to' routes with '->'. Whitespace surrounding the routes is ignored. E.g. '/from -> /to'."
+      },
+      {
+        name: 'rewrite.dropsecurecookieflag',
+        type: Boolean,
+        description: 'Drop the secure flag from remote cookies. This can be useful when rewriting to a secure location that sets secure cookies that then should get set on localhost.'
       }
     ]
   }
@@ -41,7 +46,7 @@ class Rewrite extends EventEmitter {
   }
 }
 
-function proxyRequest (route, mw) {
+function proxyRequest (route, mw, lws) {
   let id = 1
 
   let httpProxyAgent, httpsProxyAgent
@@ -130,6 +135,9 @@ function proxyRequest (route, mw) {
           headers: remoteRes.headers
         })
         util.removeHopSpecificHeaders(remoteRes.headers)
+        if (lws.config.rewriteDropsecurecookieflag) {
+          util.removeFlagFromCookies(remoteRes.headers, 'secure')
+        }
         ctx.res.writeHead(remoteRes.statusCode, remoteRes.headers)
         remoteRes.pipe(ctx.res)
         resolve()

--- a/lib/util.js
+++ b/lib/util.js
@@ -51,6 +51,18 @@ function removeHopSpecificHeaders (headers) {
   }
 }
 
+function removeFlagFromCookies (headers, flag) {
+  if (headers['set-cookie']) {
+    const replace = ';\\s*' + flag
+    const re = new RegExp(replace, 'ig')
+    for (var i = 0; i < headers['set-cookie'].length; i++) {
+      const cookie = headers['set-cookie'][i]
+      headers['set-cookie'][i] = cookie.replace(re, '')
+    }
+  }
+}
+
 exports.parseRewriteRules = parseRewriteRules
 exports.getToUrl = getToUrl
 exports.removeHopSpecificHeaders = removeHopSpecificHeaders
+exports.removeFlagFromCookies = removeFlagFromCookies

--- a/lib/util.js
+++ b/lib/util.js
@@ -51,18 +51,14 @@ function removeHopSpecificHeaders (headers) {
   }
 }
 
-function removeFlagFromCookies (headers, flag) {
-  if (headers['set-cookie']) {
-    const replace = ';\\s*' + flag
-    const re = new RegExp(replace, 'ig')
-    for (var i = 0; i < headers['set-cookie'].length; i++) {
-      const cookie = headers['set-cookie'][i]
-      headers['set-cookie'][i] = cookie.replace(re, '')
-    }
-  }
+function removeCookieAttribute (cookie = '', attr) {
+  return cookie.split(';')
+    .map(a => a.trim())
+    .filter(a => a.toLowerCase() !== attr)
+    .join('; ')
 }
 
 exports.parseRewriteRules = parseRewriteRules
 exports.getToUrl = getToUrl
 exports.removeHopSpecificHeaders = removeHopSpecificHeaders
-exports.removeFlagFromCookies = removeFlagFromCookies
+exports.removeCookieAttribute = removeCookieAttribute

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=8"
   },
   "scripts": {
-    "test": "npx test-runner test/local.js test/remote.js test/util.js && npx test-runner test/http-proxy.js",
+    "test": "test-runner test/local.js test/remote.js test/util.js && test-runner test/http-proxy.js",
     "cover": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {

--- a/test/remote.js
+++ b/test/remote.js
@@ -239,7 +239,7 @@ tom.test('GET HTTPS, self-signed', async function () {
   }
 }, { timeout: 120000 })
 
-tom.test('GET HTTPS, secure cookie attribute set', async function () {
+tom.test('GET HTTPS, secure cookie attribute set - remove it', async function () {
   class SecureCookie {
     middleware (config, lws) {
       return function (ctx, next) {
@@ -266,14 +266,14 @@ tom.test('GET HTTPS, secure cookie attribute set', async function () {
   try {
     const response = await fetch(`http://localhost:${port}/`)
     a.strictEqual(response.status, 200)
-    a.strictEqual(response.headers.get('set-cookie'), 'test=one; path=/; secure; httponly')
+    a.strictEqual(response.headers.get('set-cookie'), 'test=one; path=/; httponly')
   } finally {
     lws.server.close()
     remoteLws.server.close()
   }
 }, { timeout: 120000 })
 
-tom.test('GET HTTPS, rmeove secure cookie attribute', async function () {
+tom.test('GET HTTPS, --rewrite.keep-secure-attr', async function () {
   class SecureCookie {
     middleware (config, lws) {
       return function (ctx, next) {
@@ -296,19 +296,19 @@ tom.test('GET HTTPS, rmeove secure cookie attribute', async function () {
     port,
     stack: [ Rewrite, Static ],
     rewrite: { from: '/', to: `https://localhost:${remotePort}/` },
-    rewriteDropSecureAttr: true
+    rewriteKeepSecureAttr: true
   })
   try {
     const response = await fetch(`http://localhost:${port}/`)
     a.strictEqual(response.status, 200)
-    a.strictEqual(response.headers.get('set-cookie'), 'test=one; path=/; httponly')
+    a.strictEqual(response.headers.get('set-cookie'), 'test=one; path=/; secure; httponly')
   } finally {
     lws.server.close()
     remoteLws.server.close()
   }
 }, { timeout: 120000 })
 
-tom.test('GET HTTPS, rmeove secure cookie attribute, multiple cookies', async function () {
+tom.test('GET HTTPS, --rewrite.keep-secure-attr, multiple cookies', async function () {
   class SecureCookie {
     middleware (config, lws) {
       return function (ctx, next) {
@@ -332,12 +332,12 @@ tom.test('GET HTTPS, rmeove secure cookie attribute, multiple cookies', async fu
     port,
     stack: [ Rewrite, Static ],
     rewrite: { from: '/', to: `https://localhost:${remotePort}/` },
-    rewriteDropSecureAttr: true
+    rewriteKeepSecureAttr: true
   })
   try {
     const response = await fetch(`http://localhost:${port}/`)
     a.strictEqual(response.status, 200)
-    a.strictEqual(response.headers.get('set-cookie'), 'test=one; path=/; httponly, test2=two; path=/; httponly')
+    a.strictEqual(response.headers.get('set-cookie'), 'test=one; path=/; secure; httponly, test2=two; path=/; secure; httponly')
   } finally {
     lws.server.close()
     remoteLws.server.close()

--- a/test/remote.js
+++ b/test/remote.js
@@ -238,3 +238,108 @@ tom.test('GET HTTPS, self-signed', async function () {
     remoteLws.server.close()
   }
 }, { timeout: 120000 })
+
+tom.test('GET HTTPS, secure cookie attribute set', async function () {
+  class SecureCookie {
+    middleware (config, lws) {
+      return function (ctx, next) {
+        const secure = true
+        const lastVisit = ctx.cookies.get('lastVisit')
+        ctx.cookies.set('test', 'one', { secure })
+        ctx.body = 'test'
+      }
+    }
+  }
+  const remotePort = 10000 + this.index
+  const remoteLws = Lws.create({
+    port: remotePort,
+    https: true,
+    stack: [ SecureCookie ]
+  })
+
+  const port = 8100 + this.index
+  const lws = Lws.create({
+    port,
+    stack: [ Rewrite, Static ],
+    rewrite: { from: '/', to: `https://localhost:${remotePort}/` }
+  })
+  try {
+    const response = await fetch(`http://localhost:${port}/`)
+    a.strictEqual(response.status, 200)
+    a.strictEqual(response.headers.get('set-cookie'), 'test=one; path=/; secure; httponly')
+  } finally {
+    lws.server.close()
+    remoteLws.server.close()
+  }
+}, { timeout: 120000 })
+
+tom.test('GET HTTPS, rmeove secure cookie attribute', async function () {
+  class SecureCookie {
+    middleware (config, lws) {
+      return function (ctx, next) {
+        const secure = true
+        const lastVisit = ctx.cookies.get('lastVisit')
+        ctx.cookies.set('test', 'one', { secure })
+        ctx.body = 'test'
+      }
+    }
+  }
+  const remotePort = 10000 + this.index
+  const remoteLws = Lws.create({
+    port: remotePort,
+    https: true,
+    stack: [ SecureCookie ]
+  })
+
+  const port = 8100 + this.index
+  const lws = Lws.create({
+    port,
+    stack: [ Rewrite, Static ],
+    rewrite: { from: '/', to: `https://localhost:${remotePort}/` },
+    rewriteDropSecureAttr: true
+  })
+  try {
+    const response = await fetch(`http://localhost:${port}/`)
+    a.strictEqual(response.status, 200)
+    a.strictEqual(response.headers.get('set-cookie'), 'test=one; path=/; httponly')
+  } finally {
+    lws.server.close()
+    remoteLws.server.close()
+  }
+}, { timeout: 120000 })
+
+tom.test('GET HTTPS, rmeove secure cookie attribute, multiple cookies', async function () {
+  class SecureCookie {
+    middleware (config, lws) {
+      return function (ctx, next) {
+        const secure = true
+        const lastVisit = ctx.cookies.get('lastVisit')
+        ctx.cookies.set('test', 'one', { secure })
+        ctx.cookies.set('test2', 'two', { secure })
+        ctx.body = 'test'
+      }
+    }
+  }
+  const remotePort = 10000 + this.index
+  const remoteLws = Lws.create({
+    port: remotePort,
+    https: true,
+    stack: [ SecureCookie ]
+  })
+
+  const port = 8100 + this.index
+  const lws = Lws.create({
+    port,
+    stack: [ Rewrite, Static ],
+    rewrite: { from: '/', to: `https://localhost:${remotePort}/` },
+    rewriteDropSecureAttr: true
+  })
+  try {
+    const response = await fetch(`http://localhost:${port}/`)
+    a.strictEqual(response.status, 200)
+    a.strictEqual(response.headers.get('set-cookie'), 'test=one; path=/; httponly, test2=two; path=/; httponly')
+  } finally {
+    lws.server.close()
+    remoteLws.server.close()
+  }
+}, { timeout: 120000 })

--- a/test/util.js
+++ b/test/util.js
@@ -72,3 +72,27 @@ tom.test('removeHopSpecificHeaders', async function () {
   util.removeHopSpecificHeaders(headers)
   a.deepStrictEqual(headers, {})
 })
+
+tom.test('removeCookieAttribute', async function () {
+  const setCookie = 'lastVisit=03/02/2020, 23:02:40; path=/; secure; httponly'
+  const result = util.removeCookieAttribute(setCookie, 'secure')
+  a.strictEqual(result, 'lastVisit=03/02/2020, 23:02:40; path=/; httponly')
+})
+
+tom.test('removeCookieAttribute 2', async function () {
+  const setCookie = 'lastVisit=03/02/2020, 23:02:40;Secure; httponly'
+  const result = util.removeCookieAttribute(setCookie, 'secure')
+  a.strictEqual(result, 'lastVisit=03/02/2020, 23:02:40; httponly')
+})
+
+tom.test('removeCookieAttribute 3', async function () {
+  const setCookie = ''
+  const result = util.removeCookieAttribute(setCookie, 'secure')
+  a.strictEqual(result, '')
+})
+
+tom.test('removeCookieAttribute 4', async function () {
+  const setCookie = undefined
+  const result = util.removeCookieAttribute(setCookie, 'secure')
+  a.strictEqual(result, '')
+})


### PR DESCRIPTION
This can be useful when rewriting to a secure location that sets secure cookies that
then should get set on localhost during development.

This commit fixes https://github.com/lwsjs/local-web-server/issues/141